### PR TITLE
[iCubGenova09] wholeBodyDynamics use MAS RFE  IMU

### DIFF
--- a/iCubGenova09/estimators/wholebodydynamics.xml
+++ b/iCubGenova09/estimators/wholebodydynamics.xml
@@ -19,6 +19,10 @@
         <param name="jointAccFilterCutoffInHz">3.0</param> <!-- used if useJointAcceleration is set to true -->
         <param name="useSkinForContacts">false</param>
 	<!--        <param name="assume_fixed">root_link</param>-->
+	<group name="HW_USE_MAS_IMU">
+	    <param name="accelerometer">rfeimu_acc</param>
+	    <param name="gyroscope">rfeimu_gyro</param>
+	</group>
 
 
         <group name="GRAVITY_COMPENSATION">


### PR DESCRIPTION
This PR allows the wholeBodyDynamics to run as expected on iCubGenova09 which is equipped with a RFE IMU on the head and streams data through the MAS interface and not the analog sensor interface.