### PR TITLE
Fix iRonCub experiment

### DIFF
--- a/iRonCub-Mk1/estimators/wholebodydynamics_iRonCub_noFeet.xml
+++ b/iRonCub-Mk1/estimators/wholebodydynamics_iRonCub_noFeet.xml
@@ -34,8 +34,8 @@
             <param name="r_elbow_1">(r_elbow_1, 4, 4)</param>
             <param name="l_lower_leg">(l_lower_leg,5,3)</param>
             <param name="l_ankle_1">(l_ankle_1,5,4)</param>
-            <param name="l_foot">(l_foot_dh_frame,5,5)</param-->
-            <param name="r_foot">(r_foot_dh_frame,6,5)</param-->
+            <param name="l_foot">(l_foot_dh_frame,5,5)</param>
+            <param name="r_foot">(r_foot_dh_frame,6,5)</param>
             <param name="r_lower_leg">(r_lower_leg,6,3)</param>
             <param name="r_ankle_1">(r_ankle_1,6,4)</param>
             <param name="r_ankle_2">(r_foot_dh_frame,6,5)</param>

--- a/iRonCub-Mk1/estimators/wholebodydynamics_iRonCub_noFeet.xml
+++ b/iRonCub-Mk1/estimators/wholebodydynamics_iRonCub_noFeet.xml
@@ -34,8 +34,8 @@
             <param name="r_elbow_1">(r_elbow_1, 4, 4)</param>
             <param name="l_lower_leg">(l_lower_leg,5,3)</param>
             <param name="l_ankle_1">(l_ankle_1,5,4)</param>
-            <!--param name="l_foot">(l_foot_dh_frame,5,5)</param-->
-            <!--param name="r_foot">(r_foot_dh_frame,6,5)</param-->
+            <param name="l_foot">(l_foot_dh_frame,5,5)</param-->
+            <param name="r_foot">(r_foot_dh_frame,6,5)</param-->
             <param name="r_lower_leg">(r_lower_leg,6,3)</param>
             <param name="r_ankle_1">(r_ankle_1,6,4)</param>
             <param name="r_ankle_2">(r_foot_dh_frame,6,5)</param>


### PR DESCRIPTION
The skin related code in `wholeBodyDynamics` was giving these errors:

```
skinDynLibConversionsHelper::fromSkinDynLibToiDynTree : link l_foot not found, skipping contact
skinDynLibConversionsHelper::fromSkinDynLibToiDynTree : link r_foot not found, skipping contact
```

@traversaro said in Teams:

[7/21, 3:07 PM] Silvio Traversaro
    
The problem that Daniele Pucci sent me seems due to this line
https://github.com/robotology/whole-body-estimators/blob/e89c4ea660c901d902b443dd8aacbe1ceb03c7e5/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.cpp#L2316 

```c++
conversionHelper.fromSkinDynLibToiDynTree(estimator.model(),contactsReadFromSkin,measuredContactLocations);
```

and it seems that there is a default contact on a link, that then is not given in `IDYNTREE_SKINDYNLIB_LINKS`


Given that due to https://github.com/dic-iit/robots-configuration/blob/devel_iCubGenova04/iRonCub-Mk1/estimators/wholebodydynamics_iRonCub_noFeet.xml#L21

```xml
<param name="additionalConsideredFixedJoints">(l_foot_ft_sensor,r_foot_ft_sensor)</param> <!-- Feet FT sensors are removed from the URDF model so these fixed joints should be added explicitly-->
```

now the `l_foot` and `r_foot` are considered links, I think that the default contact on `l_sole` is considered and the `l_foot` link, and so we need to uncomment lines 37 and 38.

