### PR TITLE
Fix Bosch IMU name

### DIFF
--- a/iCubGenova04/hardware/inertials/head-inertial.xml
+++ b/iCubGenova04/hardware/inertials/head-inertial.xml
@@ -3,6 +3,6 @@
 
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="head-inertial" type="imuBosch_BNO055">
-      <param name="i2c">  /dev/icub-i2c-imu   </param>
+      <param name="i2c">  /dev/bosch-i2c-imu   </param>
 </device>
 

--- a/iRonCub-Mk1/hardware/inertials/head-inertial.xml
+++ b/iRonCub-Mk1/hardware/inertials/head-inertial.xml
@@ -3,6 +3,6 @@
 
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="head-inertial" type="imuBosch_BNO055">
-      <param name="i2c">  /dev/icub-i2c-imu   </param>
+      <param name="i2c">  /dev/bosch-i2c-imu   </param>
 </device>
 


### PR DESCRIPTION
See https://github.com/ami-iit/component_ironcub/issues/493#issuecomment-1016337020:

@traversaro:

> The "official" place in which this is documented is https://github.com/icub-tech-iit/documentation/blob/912f8c51b61eb3108eee158de87feb7893803165/docs/icub_operating_systems/icubos/installation-from-scratch.md#fixed-usb-resources-names . Given that there the name was `/dev/bosch-i2c-imu` for a long time (at least one year, see: https://github.com/icub-tech-iit/documentation/blame/912f8c51b61eb3108eee158de87feb7893803165/docs/icub_operating_systems/icubos/installation-from-scratch.md).
>
> I think that the "bug" was in the old setup of the iCubGenova04, not on the iCubOS image. Probably we can just fix the configuration files for iCubGenova04 and iRonCub-Mk1 .