### PR TITLE
Install all iRonCub versions by default

### DIFF
--- a/iRonCub-Mk1/CMakeLists.txt
+++ b/iRonCub-Mk1/CMakeLists.txt
@@ -2,7 +2,7 @@ file(GLOB xml ${CMAKE_CURRENT_SOURCE_DIR}/*.xml)
 file(GLOB ini ${CMAKE_CURRENT_SOURCE_DIR}/*.ini)
 
 # Option to install all iRonCub robots
-option(INSTALL_ALL_IRONCUB_VERSIONS "Install all variations of iRonCub robots." FALSE)
+option(INSTALL_ALL_IRONCUB_VERSIONS "Install all variations of iRonCub robots." TRUE)
 
 if(INSTALL_ALL_IRONCUB_VERSIONS)
     set(robot_list iRonCub-Mk1 iRonCub-Mk1_1) #Add to the list other iRonCub versions (that share the same configuration files)


### PR DESCRIPTION
Related comment https://github.com/ami-iit/component_ironcub/issues/493#issuecomment-1015721070:

> Back in time we added also the files of `iRonCub-Mk1_1`, and they would be installed if we enable the option `INASTALL_ALL_IRONCUB_VERSIONS` to `ON`. See https://github.com/ami-iit/robots-configuration/pull/9
> 
> But because it's `false` by default, we always forget to enable it and spend time to try to understand why `iRonCub-Mk1_1` are not installed.
>
> So it makes sense to have this option `ON` by default.