### PR TITLE
[iCubGenova09] Increase the speed of the low level (WBD 500Hz)

### DIFF
--- a/iCubGenova09/estimators/wholebodydynamics.xml
+++ b/iCubGenova09/estimators/wholebodydynamics.xml
@@ -17,6 +17,7 @@
         <param name="forceTorqueFilterCutoffInHz">2.0</param>
         <param name="jointVelFilterCutoffInHz">3.0</param> <!-- used if useJointVelocity is set to true -->
         <param name="jointAccFilterCutoffInHz">3.0</param> <!-- used if useJointAcceleration is set to true -->
+	<param name="devicePeriodInSeconds">0.002</param>
         <param name="useSkinForContacts">false</param>
         <param name="publishNetExternalWrenches">true</param>
         <param name="estimateJointVelocityAcceleration">false</param>  <!-- if true a kf will estimate the joint velocities and accelerations -->

--- a/iCubGenova09/hardware/FT/left_arm-eb1-j0_1-strain.xml
+++ b/iCubGenova09/hardware/FT/left_arm-eb1-j0_1-strain.xml
@@ -39,7 +39,7 @@
 
             <group name="SETTINGS">        
                 <param name="enabledSensors">       l_arm_ft_sensor               </param>
-                <param name="ftPeriod">             10         		                    </param>
+                <param name="ftPeriod">             2         		                    </param>
                 <param name="temperaturePeriod">    1000      		                   </param>
                 <param name="useCalibration">       true      		              </param>           
             </group>       

--- a/iCubGenova09/hardware/FT/left_leg-eb7-j0_2-strain.xml
+++ b/iCubGenova09/hardware/FT/left_leg-eb7-j0_2-strain.xml
@@ -39,7 +39,7 @@
 
             <group name="SETTINGS">        
                 <param name="enabledSensors">       l_leg_ft_sensor               </param>
-                <param name="ftPeriod">             10         		                    </param>
+                <param name="ftPeriod">             2         		                    </param>
                 <param name="temperaturePeriod">    1000      		                   </param>
                 <param name="useCalibration">       true      		              </param>           
             </group>       

--- a/iCubGenova09/hardware/FT/left_leg-eb8-j3_5-strain.xml
+++ b/iCubGenova09/hardware/FT/left_leg-eb8-j3_5-strain.xml
@@ -39,7 +39,7 @@
 
             <group name="SETTINGS">        
                 <param name="enabledSensors">       l_foot_rear_ft_sensor          l_foot_front_ft_sensor      </param>
-                <param name="ftPeriod">             10         		 10                     </param>
+                <param name="ftPeriod">             2         		 2                     </param>
                 <param name="temperaturePeriod">    1000      		 1000                    </param>
                 <param name="useCalibration">       true      		 true                 </param>           
             </group>       

--- a/iCubGenova09/hardware/FT/right_arm-eb3-j0_1-strain.xml
+++ b/iCubGenova09/hardware/FT/right_arm-eb3-j0_1-strain.xml
@@ -39,7 +39,7 @@
 
             <group name="SETTINGS">        
                 <param name="enabledSensors">       r_arm_ft_sensor               </param>
-                <param name="ftPeriod">             10         		                    </param>
+                <param name="ftPeriod">             2         		                    </param>
                 <param name="temperaturePeriod">    1000      		                   </param>
                 <param name="useCalibration">       true      		              </param>           
             </group>       

--- a/iCubGenova09/hardware/FT/right_leg-eb11-j0_2-strain.xml
+++ b/iCubGenova09/hardware/FT/right_leg-eb11-j0_2-strain.xml
@@ -39,7 +39,7 @@
 
             <group name="SETTINGS">        
                 <param name="enabledSensors">       r_leg_ft_sensor           </param>
-                <param name="ftPeriod">             10         		                    </param>
+                <param name="ftPeriod">             2         		                    </param>
                 <param name="temperaturePeriod">    1000      		                   </param>
                 <param name="useCalibration">       true      		              </param>           
             </group>       

--- a/iCubGenova09/hardware/FT/right_leg-eb12-j3_5-strain.xml
+++ b/iCubGenova09/hardware/FT/right_leg-eb12-j3_5-strain.xml
@@ -39,7 +39,7 @@
 
             <group name="SETTINGS">        
                 <param name="enabledSensors">       r_foot_rear_ft_sensor          r_foot_front_ft_sensor       </param>
-                <param name="ftPeriod">             10         		 10                     </param>
+                <param name="ftPeriod">             2         		 2                     </param>
                 <param name="temperaturePeriod">    1000      		 1000                    </param>
                 <param name="useCalibration">       true      		 true                 </param>           
             </group>       

--- a/iCubGenova09/hardware/electronics/face-eb22-j0-eln.xml
+++ b/iCubGenova09/hardware/electronics/face-eb22-j0-eln.xml
@@ -22,7 +22,7 @@
                 <param name="maxTimeOfRXactivity">      400                 </param>
                 <param name="maxTimeOfDOactivity">      300                 </param>   
                 <param name="maxTimeOfTXactivity">      300                 </param>                
-                <param name="TXrateOfRegularROPs">      3                   </param> 
+                <param name="TXrateOfRegularROPs">      2                   </param> 
             </group>              
         </group>                 
         

--- a/iCubGenova09/hardware/electronics/face-eb22-j0_1-eln.xml
+++ b/iCubGenova09/hardware/electronics/face-eb22-j0_1-eln.xml
@@ -22,7 +22,7 @@
                 <param name="maxTimeOfRXactivity">      400                 </param>
                 <param name="maxTimeOfDOactivity">      300                 </param>   
                 <param name="maxTimeOfTXactivity">      300                 </param>                
-                <param name="TXrateOfRegularROPs">      3                   </param> 
+                <param name="TXrateOfRegularROPs">      2                   </param> 
             </group>              
         </group>                 
         

--- a/iCubGenova09/hardware/electronics/face-eb23-j2_5-eln.xml
+++ b/iCubGenova09/hardware/electronics/face-eb23-j2_5-eln.xml
@@ -22,7 +22,7 @@
                 <param name="maxTimeOfRXactivity">      400                 </param>
                 <param name="maxTimeOfDOactivity">      300                 </param>   
                 <param name="maxTimeOfTXactivity">      300                 </param>                
-                <param name="TXrateOfRegularROPs">      5                   </param> 
+                <param name="TXrateOfRegularROPs">      2                   </param> 
             </group>              
         </group>                 
         

--- a/iCubGenova09/hardware/electronics/head-eb20-j0_1-eln.xml
+++ b/iCubGenova09/hardware/electronics/head-eb20-j0_1-eln.xml
@@ -22,7 +22,7 @@
                 <param name="maxTimeOfRXactivity">      400                 </param>
                 <param name="maxTimeOfDOactivity">      300                 </param>   
                 <param name="maxTimeOfTXactivity">      300                 </param>                
-                <param name="TXrateOfRegularROPs">      5                   </param> 
+                <param name="TXrateOfRegularROPs">      2                   </param> 
             </group>              
         </group>                 
         

--- a/iCubGenova09/hardware/electronics/head-eb21-j2_5-eln.xml
+++ b/iCubGenova09/hardware/electronics/head-eb21-j2_5-eln.xml
@@ -22,7 +22,7 @@
                 <param name="maxTimeOfRXactivity">      400                 </param>
                 <param name="maxTimeOfDOactivity">      300                 </param>   
                 <param name="maxTimeOfTXactivity">      300                 </param>                
-                <param name="TXrateOfRegularROPs">      5                   </param> 
+                <param name="TXrateOfRegularROPs">      2                   </param> 
             </group>              
         </group>                 
         

--- a/iCubGenova09/hardware/electronics/left_arm-eb1-j0_1-eln.xml
+++ b/iCubGenova09/hardware/electronics/left_arm-eb1-j0_1-eln.xml
@@ -22,7 +22,7 @@
                 <param name="maxTimeOfRXactivity">      400                 </param>
                 <param name="maxTimeOfDOactivity">      300                 </param>   
                 <param name="maxTimeOfTXactivity">      300                 </param>                
-                <param name="TXrateOfRegularROPs">      5                   </param> 
+                <param name="TXrateOfRegularROPs">      2                   </param> 
             </group>              
         </group>                 
         

--- a/iCubGenova09/hardware/electronics/left_arm-eb2-j2_3-eln.xml
+++ b/iCubGenova09/hardware/electronics/left_arm-eb2-j2_3-eln.xml
@@ -22,7 +22,7 @@
                 <param name="maxTimeOfRXactivity">      400                 </param>
                 <param name="maxTimeOfDOactivity">      300                 </param>   
                 <param name="maxTimeOfTXactivity">      300                 </param>                
-                <param name="TXrateOfRegularROPs">      5                   </param> 
+                <param name="TXrateOfRegularROPs">      2                   </param> 
             </group>              
         </group>                 
         

--- a/iCubGenova09/hardware/electronics/left_arm-eb24-j4_7-eln.xml
+++ b/iCubGenova09/hardware/electronics/left_arm-eb24-j4_7-eln.xml
@@ -22,7 +22,7 @@
                 <param name="maxTimeOfRXactivity">      400                 </param>
                 <param name="maxTimeOfDOactivity">      300                 </param>   
                 <param name="maxTimeOfTXactivity">      300                 </param>                
-                <param name="TXrateOfRegularROPs">      3                   </param> 
+                <param name="TXrateOfRegularROPs">      2                   </param> 
             </group>              
         </group>                 
         

--- a/iCubGenova09/hardware/electronics/left_arm-eb25-j8_11-eln.xml
+++ b/iCubGenova09/hardware/electronics/left_arm-eb25-j8_11-eln.xml
@@ -22,7 +22,7 @@
                 <param name="maxTimeOfRXactivity">      400                 </param>
                 <param name="maxTimeOfDOactivity">      300                 </param>   
                 <param name="maxTimeOfTXactivity">      300                 </param>                
-                <param name="TXrateOfRegularROPs">      5                   </param> 
+                <param name="TXrateOfRegularROPs">      2                   </param> 
             </group>              
         </group>                 
         

--- a/iCubGenova09/hardware/electronics/left_arm-eb26-j12_15-eln.xml
+++ b/iCubGenova09/hardware/electronics/left_arm-eb26-j12_15-eln.xml
@@ -22,7 +22,7 @@
                 <param name="maxTimeOfRXactivity">      400                 </param>
                 <param name="maxTimeOfDOactivity">      300                 </param>   
                 <param name="maxTimeOfTXactivity">      300                 </param>                
-                <param name="TXrateOfRegularROPs">      5                   </param> 
+                <param name="TXrateOfRegularROPs">      2                   </param> 
             </group>              
         </group>                 
         

--- a/iCubGenova09/hardware/electronics/left_leg-eb7-j0_2-eln.xml
+++ b/iCubGenova09/hardware/electronics/left_leg-eb7-j0_2-eln.xml
@@ -22,7 +22,7 @@
                 <param name="maxTimeOfRXactivity">      400                 </param>
                 <param name="maxTimeOfDOactivity">      300                 </param>   
                 <param name="maxTimeOfTXactivity">      300                 </param>                
-                <param name="TXrateOfRegularROPs">      5                   </param> 
+                <param name="TXrateOfRegularROPs">      2                   </param> 
             </group>              
         </group>                 
         

--- a/iCubGenova09/hardware/electronics/left_leg-eb8-j3_5-eln.xml
+++ b/iCubGenova09/hardware/electronics/left_leg-eb8-j3_5-eln.xml
@@ -22,7 +22,7 @@
                 <param name="maxTimeOfRXactivity">      400                 </param>
                 <param name="maxTimeOfDOactivity">      300                 </param>   
                 <param name="maxTimeOfTXactivity">      300                 </param>                
-                <param name="TXrateOfRegularROPs">      5                   </param> 
+                <param name="TXrateOfRegularROPs">      2                   </param> 
             </group>              
         </group>                 
         

--- a/iCubGenova09/hardware/electronics/pc104.xml
+++ b/iCubGenova09/hardware/electronics/pc104.xml
@@ -7,7 +7,7 @@
         <param name="PC104IpAddress">           10.0.1.104      </param>
         <param name="PC104IpPort">              12345           </param>
         <param name="PC104TXrate">              1               </param> 
-        <param name="PC104RXrate">              5               </param>
+        <param name="PC104RXrate">              2               </param>
     </group>
 
 </params>

--- a/iCubGenova09/hardware/electronics/right_arm-eb27-j4_7-eln.xml
+++ b/iCubGenova09/hardware/electronics/right_arm-eb27-j4_7-eln.xml
@@ -22,7 +22,7 @@
                 <param name="maxTimeOfRXactivity">      400                 </param>
                 <param name="maxTimeOfDOactivity">      300                 </param>   
                 <param name="maxTimeOfTXactivity">      300                 </param>                
-                <param name="TXrateOfRegularROPs">      3                   </param> 
+                <param name="TXrateOfRegularROPs">      2                   </param> 
             </group>              
         </group>                 
         

--- a/iCubGenova09/hardware/electronics/right_arm-eb28-j8_11-eln.xml
+++ b/iCubGenova09/hardware/electronics/right_arm-eb28-j8_11-eln.xml
@@ -22,7 +22,7 @@
                 <param name="maxTimeOfRXactivity">      400                 </param>
                 <param name="maxTimeOfDOactivity">      300                 </param>   
                 <param name="maxTimeOfTXactivity">      300                 </param>                
-                <param name="TXrateOfRegularROPs">      5                   </param> 
+                <param name="TXrateOfRegularROPs">      2                   </param> 
             </group>              
         </group>                 
         

--- a/iCubGenova09/hardware/electronics/right_arm-eb29-j12_15-eln.xml
+++ b/iCubGenova09/hardware/electronics/right_arm-eb29-j12_15-eln.xml
@@ -22,7 +22,7 @@
                 <param name="maxTimeOfRXactivity">      400                 </param>
                 <param name="maxTimeOfDOactivity">      300                 </param>   
                 <param name="maxTimeOfTXactivity">      300                 </param>                
-                <param name="TXrateOfRegularROPs">      5                   </param> 
+                <param name="TXrateOfRegularROPs">      2                   </param> 
             </group>              
         </group>                 
         

--- a/iCubGenova09/hardware/electronics/right_arm-eb3-j0_1-eln.xml
+++ b/iCubGenova09/hardware/electronics/right_arm-eb3-j0_1-eln.xml
@@ -22,7 +22,7 @@
                 <param name="maxTimeOfRXactivity">      400                 </param>
                 <param name="maxTimeOfDOactivity">      300                 </param>   
                 <param name="maxTimeOfTXactivity">      300                 </param>                
-                <param name="TXrateOfRegularROPs">      5                   </param> 
+                <param name="TXrateOfRegularROPs">      2                   </param> 
             </group>              
         </group>                 
         

--- a/iCubGenova09/hardware/electronics/right_arm-eb4-j2_3-eln.xml
+++ b/iCubGenova09/hardware/electronics/right_arm-eb4-j2_3-eln.xml
@@ -22,7 +22,7 @@
                 <param name="maxTimeOfRXactivity">      400                 </param>
                 <param name="maxTimeOfDOactivity">      300                 </param>   
                 <param name="maxTimeOfTXactivity">      300                 </param>                
-                <param name="TXrateOfRegularROPs">      5                   </param> 
+                <param name="TXrateOfRegularROPs">      2                   </param> 
             </group>              
         </group>                 
         

--- a/iCubGenova09/hardware/electronics/right_leg-eb11-j0_2-eln.xml
+++ b/iCubGenova09/hardware/electronics/right_leg-eb11-j0_2-eln.xml
@@ -22,7 +22,7 @@
                 <param name="maxTimeOfRXactivity">      400                 </param>
                 <param name="maxTimeOfDOactivity">      300                 </param>   
                 <param name="maxTimeOfTXactivity">      300                 </param>                
-                <param name="TXrateOfRegularROPs">      5                   </param> 
+                <param name="TXrateOfRegularROPs">      2                   </param> 
             </group>              
         </group>                 
         

--- a/iCubGenova09/hardware/electronics/right_leg-eb12-j3_5-eln.xml
+++ b/iCubGenova09/hardware/electronics/right_leg-eb12-j3_5-eln.xml
@@ -22,7 +22,7 @@
                 <param name="maxTimeOfRXactivity">      400                 </param>
                 <param name="maxTimeOfDOactivity">      300                 </param>   
                 <param name="maxTimeOfTXactivity">      300                 </param>                
-                <param name="TXrateOfRegularROPs">      5                   </param> 
+                <param name="TXrateOfRegularROPs">      2                   </param> 
             </group>              
         </group>                 
         

--- a/iCubGenova09/hardware/electronics/torso-eb5-j0_2-eln.xml
+++ b/iCubGenova09/hardware/electronics/torso-eb5-j0_2-eln.xml
@@ -22,7 +22,7 @@
                 <param name="maxTimeOfRXactivity">      400                 </param>
                 <param name="maxTimeOfDOactivity">      300                 </param>   
                 <param name="maxTimeOfTXactivity">      300                 </param>                
-                <param name="TXrateOfRegularROPs">      5                   </param> 
+                <param name="TXrateOfRegularROPs">      2                   </param> 
             </group>              
         </group>                 
         

--- a/iCubGenova09/hardware/inertials/left_arm-eb1-IMU.xml
+++ b/iCubGenova09/hardware/inertials/left_arm-eb1-IMU.xml
@@ -38,7 +38,7 @@
             </group>
 
             <group name="SETTINGS">
-                <param name="acquisitionRate">      50      </param>
+                <param name="acquisitionRate">      10      </param>
                 <param name="enabledSensors">       l_arm_ft_acc    l_arm_ft_gyro    l_arm_ft_eul    l_arm_ft_mag    l_arm_ft_stat </param>
             </group>
         </group>

--- a/iCubGenova09/hardware/inertials/left_leg-eb7-IMU.xml
+++ b/iCubGenova09/hardware/inertials/left_leg-eb7-IMU.xml
@@ -38,7 +38,7 @@
             </group>
 
             <group name="SETTINGS">
-                <param name="acquisitionRate">      50      </param>
+                <param name="acquisitionRate">      10      </param>
                 <param name="enabledSensors">       l_leg_ft_acc    l_leg_ft_gyro    l_leg_ft_eul    l_leg_ft_mag    l_leg_ft_stat </param>
             </group>
         </group>

--- a/iCubGenova09/hardware/inertials/left_leg-eb8-IMU.xml
+++ b/iCubGenova09/hardware/inertials/left_leg-eb8-IMU.xml
@@ -38,7 +38,7 @@
             </group>
 
             <group name="SETTINGS">
-                <param name="acquisitionRate">      50      </param>
+                <param name="acquisitionRate">      10      </param>
                 <param name="enabledSensors">       l_foot_rear_ft_acc    l_foot_rear_ft_gyro    l_foot_rear_ft_eul    l_foot_rear_ft_mag    l_foot_rear_ft_stat l_foot_front_ft_acc    l_foot_front_ft_gyro    l_foot_front_ft_eul    l_foot_front_ft_mag    l_foot_front_ft_stat</param>
             </group>
         </group>

--- a/iCubGenova09/hardware/inertials/right_arm-eb3-IMU.xml
+++ b/iCubGenova09/hardware/inertials/right_arm-eb3-IMU.xml
@@ -38,7 +38,7 @@
             </group>
 
             <group name="SETTINGS">
-                <param name="acquisitionRate">      50      </param>
+                <param name="acquisitionRate">      10       </param>
                 <param name="enabledSensors">       r_arm_ft_acc    r_arm_ft_gyro    r_arm_ft_eul    r_arm_ft_mag    r_arm_ft_stat </param>
             </group>
         </group>

--- a/iCubGenova09/hardware/inertials/right_leg-eb11-IMU.xml
+++ b/iCubGenova09/hardware/inertials/right_leg-eb11-IMU.xml
@@ -38,7 +38,7 @@
             </group>
 
             <group name="SETTINGS">
-                <param name="acquisitionRate">      50      </param>
+                <param name="acquisitionRate">      10       </param>
                 <param name="enabledSensors">       r_leg_ft_acc    r_leg_ft_gyro    r_leg_ft_eul    r_leg_ft_mag    r_leg_ft_stat </param>
             </group>
         </group>

--- a/iCubGenova09/hardware/inertials/right_leg-eb12-IMU.xml
+++ b/iCubGenova09/hardware/inertials/right_leg-eb12-IMU.xml
@@ -38,7 +38,7 @@
             </group>
 
             <group name="SETTINGS">
-                <param name="acquisitionRate">      50      </param>
+                <param name="acquisitionRate">      10       </param>
                 <param name="enabledSensors">       r_foot_rear_ft_acc    r_foot_rear_ft_gyro    r_foot_rear_ft_eul    r_foot_rear_ft_mag    r_foot_rear_ft_stat r_foot_front_ft_acc    r_foot_front_ft_gyro    r_foot_front_ft_eul    r_foot_front_ft_mag    r_foot_front_ft_stat</param>
             </group>
         </group>

--- a/iCubGenova09/wrappers/FT/left_arm-FT_wrapper.xml
+++ b/iCubGenova09/wrappers/FT/left_arm-FT_wrapper.xml
@@ -3,7 +3,7 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-FT_wrapper" type="multipleanalogsensorsserver">
-        <param name="period">      10                           </param>
+        <param name="period">      2                           </param>
         <param name="name">       /icub/left_arm       </param>
         
         <action phase="startup" level="5" type="attach">

--- a/iCubGenova09/wrappers/FT/left_arm-FT_wrapper_multipleSens.xml
+++ b/iCubGenova09/wrappers/FT/left_arm-FT_wrapper_multipleSens.xml
@@ -3,7 +3,7 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-FT_wrapper" type="multipleanalogsensorsserver">
-        <param name="period">      10                           </param>
+        <param name="period">      2                           </param>
         <param name="name">       /icub/left_arm                </param>
         
         <action phase="startup" level="5" type="attach">

--- a/iCubGenova09/wrappers/FT/left_foot-FT_wrapper.xml
+++ b/iCubGenova09/wrappers/FT/left_foot-FT_wrapper.xml
@@ -3,7 +3,7 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_foot-FT_wrapper" type="multipleanalogsensorsserver">
-        <param name="period">      10                          </param>
+        <param name="period">      2                          </param>
         <param name="name">       /icub/left_foot_heel_tiptoe     </param>
         
         <action phase="startup" level="5" type="attach">

--- a/iCubGenova09/wrappers/FT/left_foot_heel-FT_wrapper.xml
+++ b/iCubGenova09/wrappers/FT/left_foot_heel-FT_wrapper.xml
@@ -3,7 +3,7 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_foot_heel-FT_wrapper" type="analogServer">
-        <param name="period">      10                          </param>
+        <param name="period">      2                          </param>
         <param name="name">       /icub/left_foot_heel/analog:o     </param>
         
         <action phase="startup" level="5" type="attach">

--- a/iCubGenova09/wrappers/FT/left_foot_heel-FT_wrapper_multipleSens.xml
+++ b/iCubGenova09/wrappers/FT/left_foot_heel-FT_wrapper_multipleSens.xml
@@ -3,7 +3,7 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_foot_heel-FT_wrapper" type="multipleanalogsensorsserver">
-        <param name="period">      10                          </param>
+        <param name="period">      2                          </param>
         <param name="name">       /icub/left_foot_heel     </param>
         
         <action phase="startup" level="5" type="attach">

--- a/iCubGenova09/wrappers/FT/left_foot_tiptoe-FT_wrapper.xml
+++ b/iCubGenova09/wrappers/FT/left_foot_tiptoe-FT_wrapper.xml
@@ -3,7 +3,7 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_foot_tiptoe-FT_wrapper" type="analogServer">
-        <param name="period">      10                          </param>
+        <param name="period">      2                          </param>
         <param name="name">       /icub/left_foot_tiptoe/analog:o     </param>
         
         <action phase="startup" level="5" type="attach">

--- a/iCubGenova09/wrappers/FT/left_foot_tiptoe-FT_wrapper_multipleSens.xml
+++ b/iCubGenova09/wrappers/FT/left_foot_tiptoe-FT_wrapper_multipleSens.xml
@@ -3,7 +3,7 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_foot_tiptoe-FT_wrapper" type="multipleanalogsensorsserver">
-        <param name="period">      10                          </param>
+        <param name="period">      2                          </param>
         <param name="name">       /icub/left_foot_tiptoe     </param>
         
         <action phase="startup" level="5" type="attach">

--- a/iCubGenova09/wrappers/FT/left_leg_hip-FT_wrapper.xml
+++ b/iCubGenova09/wrappers/FT/left_leg_hip-FT_wrapper.xml
@@ -3,7 +3,7 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg_hip-FT_wrapper" type="multipleanalogsensorsserver">
-        <param name="period">      10                          </param>
+        <param name="period">      2                          </param>
         <param name="name">       /icub/left_leg_hip     </param>
         
         <action phase="startup" level="5" type="attach">

--- a/iCubGenova09/wrappers/FT/right_arm-FT_wrapper.xml
+++ b/iCubGenova09/wrappers/FT/right_arm-FT_wrapper.xml
@@ -3,7 +3,7 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-FT_wrapper" type="multipleanalogsensorsserver">
-        <param name="period">      10                           </param>
+        <param name="period">      2                           </param>
         <param name="name">       /icub/right_arm      </param>
         
         <action phase="startup" level="5" type="attach">

--- a/iCubGenova09/wrappers/FT/right_arm-FT_wrapper_multipleSens.xml
+++ b/iCubGenova09/wrappers/FT/right_arm-FT_wrapper_multipleSens.xml
@@ -3,7 +3,7 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-FT_wrapper" type="multipleanalogsensorsserver">
-        <param name="period">      10                           </param>
+        <param name="period">      2                           </param>
         <param name="name">       /icub/right_arm               </param>
         
         <action phase="startup" level="5" type="attach">

--- a/iCubGenova09/wrappers/FT/right_foot-FT_wrapper.xml
+++ b/iCubGenova09/wrappers/FT/right_foot-FT_wrapper.xml
@@ -3,7 +3,7 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_foot-FT_wrapper" type="multipleanalogsensorsserver">
-        <param name="period">      10                          </param>
+        <param name="period">      2                          </param>
         <param name="name">       /icub/right_foot_heel_tiptoe     </param>
         
         <action phase="startup" level="5" type="attach">

--- a/iCubGenova09/wrappers/FT/right_foot_heel-FT_wrapper.xml
+++ b/iCubGenova09/wrappers/FT/right_foot_heel-FT_wrapper.xml
@@ -3,7 +3,7 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_foot_heel-FT_wrapper" type="analogServer">
-        <param name="period">      10                          </param>
+        <param name="period">      2                          </param>
         <param name="name">       /icub/right_foot_heel/analog:o     </param>
         
         <action phase="startup" level="5" type="attach">

--- a/iCubGenova09/wrappers/FT/right_foot_heel-FT_wrapper_multipleSens.xml
+++ b/iCubGenova09/wrappers/FT/right_foot_heel-FT_wrapper_multipleSens.xml
@@ -3,7 +3,7 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_foot_heel-FT_wrapper" type="multipleanalogsensorsserver">
-        <param name="period">      10                          </param>
+        <param name="period">      2                          </param>
         <param name="name">       /icub/right_foot_heel     </param>
         
         <action phase="startup" level="5" type="attach">

--- a/iCubGenova09/wrappers/FT/right_foot_tiptoe-FT_wrapper.xml
+++ b/iCubGenova09/wrappers/FT/right_foot_tiptoe-FT_wrapper.xml
@@ -3,7 +3,7 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_foot_tiptoe-FT_wrapper" type="analogServer">
-        <param name="period">      10                          </param>
+        <param name="period">      2                          </param>
         <param name="name">       /icub/right_foot_tiptoe/analog:o     </param>
         
         <action phase="startup" level="5" type="attach">

--- a/iCubGenova09/wrappers/FT/right_foot_tiptoe-FT_wrapper_multipleSens.xml
+++ b/iCubGenova09/wrappers/FT/right_foot_tiptoe-FT_wrapper_multipleSens.xml
@@ -3,7 +3,7 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_foot_tiptoe-FT_wrapper" type="multipleanalogsensorsserver">
-        <param name="period">      10                          </param>
+        <param name="period">      2                          </param>
         <param name="name">       /icub/right_foot_tiptoe     </param>
         
         <action phase="startup" level="5" type="attach">

--- a/iCubGenova09/wrappers/FT/right_leg_hip-FT_wrapper.xml
+++ b/iCubGenova09/wrappers/FT/right_leg_hip-FT_wrapper.xml
@@ -3,7 +3,7 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg_hip-FT_wrapper" type="multipleanalogsensorsserver">
-        <param name="period">      10                          </param>
+        <param name="period">      2                          </param>
         <param name="name">       /icub/right_leg_hip     </param>
         
         <action phase="startup" level="5" type="attach">

--- a/iCubGenova09/wrappers/FT/right_leg_hip-FT_wrapper_multipleSens.xml
+++ b/iCubGenova09/wrappers/FT/right_leg_hip-FT_wrapper_multipleSens.xml
@@ -3,7 +3,7 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_foot_tiptoe-FT_wrapper" type="multipleanalogsensorsserver">
-        <param name="period">      10                          </param>
+        <param name="period">      2                          </param>
         <param name="name">       /icub/right_leg_hip     </param>
         
         <action phase="startup" level="5" type="attach">

--- a/iCubGenova09/wrappers/inertials/head-imuFilter.xml
+++ b/iCubGenova09/wrappers/inertials/head-imuFilter.xml
@@ -3,7 +3,7 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="head-imuFilter" type="imuFilter">
-        <param name="period">       20                  </param>
+        <param name="period">       10                  </param>
         <param name="name">     /imuFilter              </param>
 
 

--- a/iCubGenova09/wrappers/inertials/head-imuFilter_wrapper.xml
+++ b/iCubGenova09/wrappers/inertials/head-imuFilter_wrapper.xml
@@ -3,7 +3,7 @@
 
 
     <device xmlns:xi="http://www.w3.org/2001/XInclude" name="head-imuFilter_wrapper" type="multipleanalogsensorsserver">
-        <param name="period">       20                  </param>
+        <param name="period">       10                  </param>
         <param name="name">     /imuFilter              </param>
 
 

--- a/iCubGenova09/wrappers/motorControl/face-mc_wrapper.xml
+++ b/iCubGenova09/wrappers/motorControl/face-mc_wrapper.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="face-mc_nws_yarp" type="controlBoard_nws_yarp">
-    <param name="period"> 0.01  </param>
-    <param name="name"> /icub/face   </param>
+  <param name="name"> /icub/face   </param>
+  <param name="period"> 0.002   </param>
     <action phase="startup" level="10" type="attach">
-            <param name="device">  face-mc_remapper </param>
+      <param name="device">  face-mc_remapper </param>
     </action>
     <action phase="shutdown" level="15" type="detach" />
 </device>

--- a/iCubGenova09/wrappers/motorControl/head-mc_wrapper.xml
+++ b/iCubGenova09/wrappers/motorControl/head-mc_wrapper.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="head-mc_nws_yarp" type="controlBoard_nws_yarp">
-    <param name="period"> 0.01  </param>
-    <param name="name"> /icub/head   </param>
+  <param name="name"> /icub/head   </param>
+  <param name="period"> 0.002   </param>
     <action phase="startup" level="10" type="attach">
-            <param name="device">  head-mc_remapper </param>
+      <param name="device">  head-mc_remapper </param>
     </action>
     <action phase="shutdown" level="15" type="detach" />
 </device>

--- a/iCubGenova09/wrappers/motorControl/left_arm-mc_wrapper.xml
+++ b/iCubGenova09/wrappers/motorControl/left_arm-mc_wrapper.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mc_nws_yarp" type="controlBoard_nws_yarp">
-    <param name="period"> 0.01  </param>
-    <param name="name"> /icub/left_arm </param>
+  <param name="name"> /icub/left_arm </param>
+  <param name="period"> 0.002   </param>
     <action phase="startup" level="10" type="attach">
-        <param name="device"> left_arm-mc_remapper </param>
+      <param name="device"> left_arm-mc_remapper </param>
     </action>
     <action phase="shutdown" level="15" type="detach" />
 </device>

--- a/iCubGenova09/wrappers/motorControl/left_leg-mc_wrapper.xml
+++ b/iCubGenova09/wrappers/motorControl/left_leg-mc_wrapper.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_leg-mc_nws_yarp" type="controlBoard_nws_yarp">
-    <param name="period"> 0.01  </param>
-    <param name="name"> /icub/left_leg </param>
+  <param name="name"> /icub/left_leg </param>
+  <param name="period"> 0.002   </param>
     <action phase="startup" level="10" type="attach">
-        <param name="device"> left_leg-mc_remapper </param>
+      <param name="device"> left_leg-mc_remapper </param>
     </action>
     <action phase="shutdown" level="15" type="detach" />
 </device>

--- a/iCubGenova09/wrappers/motorControl/right_arm-mc_wrapper.xml
+++ b/iCubGenova09/wrappers/motorControl/right_arm-mc_wrapper.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mc_nws_yarp" type="controlBoard_nws_yarp">
-    <param name="period"> 0.01  </param>
     <param name="name"> /icub/right_arm </param>
+    <param name="period"> 0.002   </param>
     <action phase="startup" level="10" type="attach">
-        <param name="device"> right_arm-mc_remapper </param>
+      <param name="device"> right_arm-mc_remapper </param>
     </action>
     <action phase="shutdown" level="15" type="detach" />
 </device>

--- a/iCubGenova09/wrappers/motorControl/right_leg-mc_wrapper.xml
+++ b/iCubGenova09/wrappers/motorControl/right_leg-mc_wrapper.xml
@@ -2,8 +2,8 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_leg-mc_nws_yarp" type="controlBoard_nws_yarp">
-    <param name="period"> 0.01  </param>
     <param name="name"> /icub/right_leg </param>
+    <param name="period"> 0.002   </param>
     <action phase="startup" level="10" type="attach">
         <param name="device"> right_leg-mc_remapper </param>
     </action>

--- a/iCubGenova09/wrappers/motorControl/torso-mc_wrapper.xml
+++ b/iCubGenova09/wrappers/motorControl/torso-mc_wrapper.xml
@@ -2,8 +2,8 @@
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="torso-mc_nws_yarp" type="controlBoard_nws_yarp">
-    <param name="period"> 0.01  </param>
     <param name="name"> /icub/torso </param>
+    <param name="period"> 0.002   </param>
     <action phase="startup" level="10" type="attach">
         <param name="device"> torso-mc_remapper </param>
     </action>


### PR DESCRIPTION
This PR decreases the period of the WBD from 0.01 s to 0.002s. The PR also increases the rate of the hardware devices and the network wrapper.

This comment will first details the profiling analysis and then I will analyze each parameter that I modified 

## Time profiling

### WBD profiling

Before entering into the details of the PR I would like to show you the time profiling result of WBD. The analysis has been performed by exploiting the timers I implemented in https://github.com/robotology/whole-body-estimators/pull/142


The following table contains the average time (the average time window is equal to 1 minute). The labels `publish` `computed forces` etc. refer to the different sections in the main loop in https://github.com/robotology/whole-body-estimators/pull/142/commits/d49bdd1655f1ce2e2b1e2b7306949b36f3cd5378 The label `all` indicates the time spent to perform the entire loop.


|             name            |  time average (s)  |   number of deadline miss    |    time at deadline miss (s)   |
|:-----------------------------:|:--------------:|:---------:|:--------------:|
|                       publish|0.0004850322333|         0 |              0 |
|                compute forces|0.0003449385246|         0 |              0 |
|                   calibration|5.510801666667e-07|         0 |              0 |
|                    kinematics|3.934341346667e-05|         0 |              0 |
|                 remove offset|  8.4732465e-06|         0 |              0 |
|                contact points|2.486420513333e-05|         0 |              0 |
|                  read sensors|4.683991183333e-05|         0 |              0 |
|                           all|0.0009521654851667|         1 |    0.002652847 |


Accordingly to the profiling, WBD is able to handle this frequency 🚀 

### Board messages
The boards stream sometimes the following warning. However, the robot seems working as expected.
```
[WARNING]  from BOARD 10.0.1.11 (right_leg-eb11-j0_2), src LOCAL, adr 0, time 1664s 41m 268u: (code 0x0000000d, par16 0x012e par64 0x00010093003e01e0) -> SYS: the TX phase of the control loop has last more than wanted. In par16: TX execution time [usec]. In par64: num of tx can2 and can1 frames and latest previous execution times of TX, RX, DO [usec] + .
``` 

[yarprobotinterface.txt](https://github.com/ami-iit/robots-configuration/files/9414813/yarprobotinterface.txt) contains the log of the yarprobotinterface. Perhaps @traversaro or @S-Dafarra have some hints.

## PR analysis
- `iCubGenova09/estimators/wholebodydynamics.xml` 
   - `<param name="devicePeriodInSeconds">0.002</param>` increase the frequency of wbd from the default value 100Hz to 500Hz
- `iCubGenova09/hardware/FT/left_arm-eb1-j0_1-strain.xml`
   - I decreased the `tfPeriod` from 10 ms to 2ms (500Hz)
- `iCubGenova09/hardware/electronics/face-eb23-j2_5-eln.xml`
   - I decreased the `TXrateOfRegularROPs` from 3 (or 5) to 2 (500Hz [here](https://github.com/robotology/robots-configuration/blob/f4be4b92aba5717dedd13677fe43f7c6b3a3ab5e/iCubTemplates/iCubTemplateV6_0/hardware/electronics/body_part--ebX-jA_B-eln.xml#L62-L73) you can find some documentation)
- `iCubGenova09/hardware/inertials/head-inertial.xml`
  - I decreased the `acquisitionRate` from 10 to 5 (200Hz)
- `iCubGenova09/hardware/inertials/left_arm-eb1-IMU.xml`
  - I decreased the `acquisitionRate` from 50 to 5 (200Hz). I noticed that all the inertials attached to the FT were running at 20Hz before this PR
- `iCubGenova09/wrappers/FT/left_arm-FT_wrapper.xml`
  - I decreased the `period` from 10 ms to 2ms (500Hz)
- `iCubGenova09/wrappers/inertials/left_foot-IMU_wrapper.xml`
  - I decreased the `period` from 10 ms to 2ms (500Hz)
- `iCubGenova09/wrappers/motorControl/left_arm-mc_wrapper.xml` 
   - I decreased the `period` from 0.02 s to 0.002s (500Hz). It is important to notice that `0.02 s` is the default value of the `controlBoard_nws_yarp` device so before this PR the rate was 50Hz.

---

This substitutes https://github.com/ami-iit/robots-configuration/pull/10