### PR TITLE
Update frequency of chest IMU and low level control

### DIFF
--- a/iRonCub-Mk3/extra/applications/copilot/iRonCubApp-baseEstIMUVive.xml
+++ b/iRonCub-Mk3/extra/applications/copilot/iRonCubApp-baseEstIMUVive.xml
@@ -11,7 +11,7 @@
     <!-- _______________________baseEstimatorV1 is in iRonCub-Mk1_______________________ -->
     <module>
 		<name>yarpdev</name>
-        <parameters> --device multipleanalogsensorsserver --name /icub/xsens_inertial_mas --period 10 --subdevice xsensmt --serial /dev/ttyS0 --xsensmt_period 0.001</parameters>
+        <parameters> --device multipleanalogsensorsserver --name /icub/xsens_inertial_mas --period 5 --subdevice xsensmt --serial /dev/ttyS0 --xsensmt_period 0.01 --xsensmt_gyro_period 0.005 --xsensmt_euler_period 0.005</parameters>
 		<node>${generic_node_3}</node>
 	</module>
 

--- a/iRonCub-Mk3/hardware/electronics/face-eb22-j0_1-eln.xml
+++ b/iRonCub-Mk3/hardware/electronics/face-eb22-j0_1-eln.xml
@@ -22,7 +22,7 @@
                 <param name="maxTimeOfRXactivity">      400                 </param>
                 <param name="maxTimeOfDOactivity">      300                 </param>   
                 <param name="maxTimeOfTXactivity">      300                 </param>                
-                <param name="TXrateOfRegularROPs">      2                   </param> 
+                <param name="TXrateOfRegularROPs">      5                   </param> 
             </group>              
         </group>                 
         

--- a/iRonCub-Mk3/hardware/electronics/face-eb23-j2_5-eln.xml
+++ b/iRonCub-Mk3/hardware/electronics/face-eb23-j2_5-eln.xml
@@ -22,7 +22,7 @@
                 <param name="maxTimeOfRXactivity">      400                 </param>
                 <param name="maxTimeOfDOactivity">      300                 </param>   
                 <param name="maxTimeOfTXactivity">      300                 </param>                
-                <param name="TXrateOfRegularROPs">      2                   </param> 
+                <param name="TXrateOfRegularROPs">      5                   </param> 
             </group>              
         </group>                 
         

--- a/iRonCub-Mk3/hardware/electronics/left_arm-eb1-j0_1-eln.xml
+++ b/iRonCub-Mk3/hardware/electronics/left_arm-eb1-j0_1-eln.xml
@@ -22,7 +22,7 @@
                 <param name="maxTimeOfRXactivity">      400                 </param>
                 <param name="maxTimeOfDOactivity">      300                 </param>   
                 <param name="maxTimeOfTXactivity">      300                 </param>                
-                <param name="TXrateOfRegularROPs">      5                   </param> 
+                <param name="TXrateOfRegularROPs">      2                   </param> 
             </group>              
         </group>                 
         

--- a/iRonCub-Mk3/hardware/electronics/left_arm-eb2-j2_3-eln.xml
+++ b/iRonCub-Mk3/hardware/electronics/left_arm-eb2-j2_3-eln.xml
@@ -22,7 +22,7 @@
                 <param name="maxTimeOfRXactivity">      400                 </param>
                 <param name="maxTimeOfDOactivity">      300                 </param>   
                 <param name="maxTimeOfTXactivity">      300                 </param>                
-                <param name="TXrateOfRegularROPs">      5                   </param> 
+                <param name="TXrateOfRegularROPs">      2                   </param> 
             </group>              
         </group>                 
         

--- a/iRonCub-Mk3/hardware/electronics/right_arm-eb3-j0_1-eln.xml
+++ b/iRonCub-Mk3/hardware/electronics/right_arm-eb3-j0_1-eln.xml
@@ -22,7 +22,7 @@
                 <param name="maxTimeOfRXactivity">      400                 </param>
                 <param name="maxTimeOfDOactivity">      300                 </param>   
                 <param name="maxTimeOfTXactivity">      300                 </param>                
-                <param name="TXrateOfRegularROPs">      5                   </param> 
+                <param name="TXrateOfRegularROPs">      2                   </param> 
             </group>              
         </group>                 
         

--- a/iRonCub-Mk3/hardware/electronics/right_arm-eb4-j2_3-eln.xml
+++ b/iRonCub-Mk3/hardware/electronics/right_arm-eb4-j2_3-eln.xml
@@ -22,7 +22,7 @@
                 <param name="maxTimeOfRXactivity">      400                 </param>
                 <param name="maxTimeOfDOactivity">      300                 </param>   
                 <param name="maxTimeOfTXactivity">      300                 </param>                
-                <param name="TXrateOfRegularROPs">      5                   </param> 
+                <param name="TXrateOfRegularROPs">      2                   </param> 
             </group>              
         </group>                 
         

--- a/iRonCub-Mk3/hardware/motorControl/left_arm-eb1-j0_1-mc.xml
+++ b/iRonCub-Mk3/hardware/motorControl/left_arm-eb1-j0_1-mc.xml
@@ -118,6 +118,19 @@
         <param name="deadZone">                 0.0049              0.0049              </param>
     </group>
 
+    <!-- kalman filter parameters - vel & acc estimation -->
+    <group name="KALMAN_FILTER">
+        <param name="kalmanFilterEnabled">          1              1            1          </param>
+        <param name="x0">                           0              0            0          </param>
+        <param name="x1">                           0              0            0          </param>
+        <param name="x2">                           0              0            0          </param>
+        <param name="Q0">                           0.0001         0.0001       0.0001     </param>
+        <param name="Q1">                           0.01           0.01         0.01       </param>
+        <param name="Q2">                           10             10           10         </param>
+        <param name="R">                            0.001          0.001        0.001      </param>
+        <param name="P0">                           0.000099       0.000099     0.000099   </param>
+    </group>
+
 </device>
 
 

--- a/iRonCub-Mk3/hardware/motorControl/left_arm-eb1-j0_1-mc.xml
+++ b/iRonCub-Mk3/hardware/motorControl/left_arm-eb1-j0_1-mc.xml
@@ -120,15 +120,15 @@
 
     <!-- kalman filter parameters - vel & acc estimation -->
     <group name="KALMAN_FILTER">
-        <param name="kalmanFilterEnabled">          1              1            1          </param>
-        <param name="x0">                           0              0            0          </param>
-        <param name="x1">                           0              0            0          </param>
-        <param name="x2">                           0              0            0          </param>
-        <param name="Q0">                           0.0001         0.0001       0.0001     </param>
-        <param name="Q1">                           0.01           0.01         0.01       </param>
-        <param name="Q2">                           10             10           10         </param>
-        <param name="R">                            0.001          0.001        0.001      </param>
-        <param name="P0">                           0.000099       0.000099     0.000099   </param>
+        <param name="kalmanFilterEnabled">          1              1            </param>
+        <param name="x0">                           0              0            </param>
+        <param name="x1">                           0              0            </param>
+        <param name="x2">                           0              0            </param>
+        <param name="Q0">                           0.0001         0.0001       </param>
+        <param name="Q1">                           0.01           0.01         </param>
+        <param name="Q2">                           10             10           </param>
+        <param name="R">                            0.001          0.001        </param>
+        <param name="P0">                           0.000099       0.000099     </param>
     </group>
 
 </device>

--- a/iRonCub-Mk3/hardware/motorControl/left_arm-eb2-j2_3-mc.xml
+++ b/iRonCub-Mk3/hardware/motorControl/left_arm-eb2-j2_3-mc.xml
@@ -118,6 +118,19 @@
         <param name="deadZone">                 0.0049              0.0049              </param>
     </group>
 
+    <!-- kalman filter parameters - vel & acc estimation -->
+    <group name="KALMAN_FILTER">
+        <param name="kalmanFilterEnabled">          1              1            1          </param>
+        <param name="x0">                           0              0            0          </param>
+        <param name="x1">                           0              0            0          </param>
+        <param name="x2">                           0              0            0          </param>
+        <param name="Q0">                           0.0001         0.0001       0.0001     </param>
+        <param name="Q1">                           0.01           0.01         0.01       </param>
+        <param name="Q2">                           10             10           10         </param>
+        <param name="R">                            0.001          0.001        0.001      </param>
+        <param name="P0">                           0.000099       0.000099     0.000099   </param>
+    </group>
+
 </device>
 
 

--- a/iRonCub-Mk3/hardware/motorControl/left_arm-eb2-j2_3-mc.xml
+++ b/iRonCub-Mk3/hardware/motorControl/left_arm-eb2-j2_3-mc.xml
@@ -120,15 +120,15 @@
 
     <!-- kalman filter parameters - vel & acc estimation -->
     <group name="KALMAN_FILTER">
-        <param name="kalmanFilterEnabled">          1              1            1          </param>
-        <param name="x0">                           0              0            0          </param>
-        <param name="x1">                           0              0            0          </param>
-        <param name="x2">                           0              0            0          </param>
-        <param name="Q0">                           0.0001         0.0001       0.0001     </param>
-        <param name="Q1">                           0.01           0.01         0.01       </param>
-        <param name="Q2">                           10             10           10         </param>
-        <param name="R">                            0.001          0.001        0.001      </param>
-        <param name="P0">                           0.000099       0.000099     0.000099   </param>
+        <param name="kalmanFilterEnabled">          1              1            </param>
+        <param name="x0">                           0              0            </param>
+        <param name="x1">                           0              0            </param>
+        <param name="x2">                           0              0            </param>
+        <param name="Q0">                           0.0001         0.0001       </param>
+        <param name="Q1">                           0.01           0.01         </param>
+        <param name="Q2">                           10             10           </param>
+        <param name="R">                            0.001          0.001        </param>
+        <param name="P0">                           0.000099       0.000099     </param>
     </group>
 
 </device>

--- a/iRonCub-Mk3/hardware/motorControl/right_arm-eb3-j0_1-mc.xml
+++ b/iRonCub-Mk3/hardware/motorControl/right_arm-eb3-j0_1-mc.xml
@@ -122,15 +122,15 @@
 
     <!-- kalman filter parameters - vel & acc estimation -->
     <group name="KALMAN_FILTER">
-        <param name="kalmanFilterEnabled">          1              1            1          </param>
-        <param name="x0">                           0              0            0          </param>
-        <param name="x1">                           0              0            0          </param>
-        <param name="x2">                           0              0            0          </param>
-        <param name="Q0">                           0.0001         0.0001       0.0001     </param>
-        <param name="Q1">                           0.01           0.01         0.01       </param>
-        <param name="Q2">                           10             10           10         </param>
-        <param name="R">                            0.001          0.001        0.001      </param>
-        <param name="P0">                           0.000099       0.000099     0.000099   </param>
+        <param name="kalmanFilterEnabled">          1              1            </param>
+        <param name="x0">                           0              0            </param>
+        <param name="x1">                           0              0            </param>
+        <param name="x2">                           0              0            </param>
+        <param name="Q0">                           0.0001         0.0001       </param>
+        <param name="Q1">                           0.01           0.01         </param>
+        <param name="Q2">                           10             10           </param>
+        <param name="R">                            0.001          0.001        </param>
+        <param name="P0">                           0.000099       0.000099     </param>
     </group>
 
   </device>

--- a/iRonCub-Mk3/hardware/motorControl/right_arm-eb3-j0_1-mc.xml
+++ b/iRonCub-Mk3/hardware/motorControl/right_arm-eb3-j0_1-mc.xml
@@ -120,6 +120,19 @@
         <param name="deadZone">                 0.0049              0.0049              </param>
     </group>
 
+    <!-- kalman filter parameters - vel & acc estimation -->
+    <group name="KALMAN_FILTER">
+        <param name="kalmanFilterEnabled">          1              1            1          </param>
+        <param name="x0">                           0              0            0          </param>
+        <param name="x1">                           0              0            0          </param>
+        <param name="x2">                           0              0            0          </param>
+        <param name="Q0">                           0.0001         0.0001       0.0001     </param>
+        <param name="Q1">                           0.01           0.01         0.01       </param>
+        <param name="Q2">                           10             10           10         </param>
+        <param name="R">                            0.001          0.001        0.001      </param>
+        <param name="P0">                           0.000099       0.000099     0.000099   </param>
+    </group>
+
   </device>
 
 

--- a/iRonCub-Mk3/hardware/motorControl/right_arm-eb4-j2_3-mc.xml
+++ b/iRonCub-Mk3/hardware/motorControl/right_arm-eb4-j2_3-mc.xml
@@ -122,15 +122,15 @@
 
     <!-- kalman filter parameters - vel & acc estimation -->
     <group name="KALMAN_FILTER">
-        <param name="kalmanFilterEnabled">          1              1            1          </param>
-        <param name="x0">                           0              0            0          </param>
-        <param name="x1">                           0              0            0          </param>
-        <param name="x2">                           0              0            0          </param>
-        <param name="Q0">                           0.0001         0.0001       0.0001     </param>
-        <param name="Q1">                           0.01           0.01         0.01       </param>
-        <param name="Q2">                           10             10           10         </param>
-        <param name="R">                            0.001          0.001        0.001      </param>
-        <param name="P0">                           0.000099       0.000099     0.000099   </param>
+        <param name="kalmanFilterEnabled">          1              1            </param>
+        <param name="x0">                           0              0            </param>
+        <param name="x1">                           0              0            </param>
+        <param name="x2">                           0              0            </param>
+        <param name="Q0">                           0.0001         0.0001       </param>
+        <param name="Q1">                           0.01           0.01         </param>
+        <param name="Q2">                           10             10           </param>
+        <param name="R">                            0.001          0.001        </param>
+        <param name="P0">                           0.000099       0.000099     </param>
     </group>
 
   </device>

--- a/iRonCub-Mk3/hardware/motorControl/right_arm-eb4-j2_3-mc.xml
+++ b/iRonCub-Mk3/hardware/motorControl/right_arm-eb4-j2_3-mc.xml
@@ -120,6 +120,19 @@
         <param name="deadZone">                 0.0049              0.0049              </param>
     </group>
 
+    <!-- kalman filter parameters - vel & acc estimation -->
+    <group name="KALMAN_FILTER">
+        <param name="kalmanFilterEnabled">          1              1            1          </param>
+        <param name="x0">                           0              0            0          </param>
+        <param name="x1">                           0              0            0          </param>
+        <param name="x2">                           0              0            0          </param>
+        <param name="Q0">                           0.0001         0.0001       0.0001     </param>
+        <param name="Q1">                           0.01           0.01         0.01       </param>
+        <param name="Q2">                           10             10           10         </param>
+        <param name="R">                            0.001          0.001        0.001      </param>
+        <param name="P0">                           0.000099       0.000099     0.000099   </param>
+    </group>
+
   </device>
 
 

--- a/iRonCub-Mk3/wrappers/motorControl/left_arm-mc_wrapper.xml
+++ b/iRonCub-Mk3/wrappers/motorControl/left_arm-mc_wrapper.xml
@@ -3,7 +3,7 @@
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mc_nws_yarp" type="controlBoard_nws_yarp">
   <param name="name"> /icub/left_arm </param>
-  <param name="period"> 0.005   </param>
+  <param name="period"> 0.002   </param>
     <action phase="startup" level="10" type="attach">
       <param name="device"> left_arm-mc_remapper </param>
     </action>

--- a/iRonCub-Mk3/wrappers/motorControl/right_arm-mc_wrapper.xml
+++ b/iRonCub-Mk3/wrappers/motorControl/right_arm-mc_wrapper.xml
@@ -3,7 +3,7 @@
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mc_nws_yarp" type="controlBoard_nws_yarp">
     <param name="name"> /icub/right_arm </param>
-    <param name="period"> 0.005   </param>
+    <param name="period"> 0.002   </param>
     <action phase="startup" level="10" type="attach">
       <param name="device"> right_arm-mc_remapper </param>
     </action>


### PR DESCRIPTION
I open this PR in order to change the set the frequency of the IMU mounted on the chest to 200 Hz and set the frequency of the low level control of all the joints but the head to 500 Hz.
Moreover, I added the Kalman filter group for the joints of the right and left arms since, as I found out in https://github.com/ami-iit/component_ironcub/issues/895, it was set only for the legs.