### PR TITLE
Updated laptop addresses and chest IMU config file

### DIFF
--- a/iRonCub-Mk3/extra/contexts/yarpmanager/cluster-config.xml
+++ b/iRonCub-Mk3/extra/contexts/yarpmanager/cluster-config.xml
@@ -8,10 +8,10 @@ this is usually the value of the DISPLAY variable when logged on -->
 
 <node user="icub" address="10.0.2.2">icub-head</node>
 <node user="icub" address="10.0.2.3">icub-cam-head</node>
-<node user="icub" display=":1" address="10.0.2.4">ironcub-pilot</node>
-<node user="icub" display=":1" address="10.0.2.5">ironcub-copilot</node>
+<node user="aliencub" display=":1" address="10.0.2.7">ironcub-pilot</node>
+<node user="icub" display=":1" address="10.0.2.4">ironcub-copilot</node>
 <node user="ironcub" display=":1" address="10.0.0.170">alienCub</node>
-<node user="ironcub" display=":1" address="10.0.2.6">ironLogger</node>
+<node user="icub" display=":1" address="10.0.2.5">ironLogger</node>
 <node user="ironpi" address="10.0.2.160">ironpiWebcam</node>
 <node user="ironpi" address="10.0.0.155">ironpiTestbench</node>
 

--- a/iRonCub-Mk3/hardware/inertials/chest-inertial.xml
+++ b/iRonCub-Mk3/hardware/inertials/chest-inertial.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
   <device type="xsensmt" name="chest-inertial">
-    <param name="serial">  /dev/ttyUSB0   </param>
+    <param name="serial">  /dev/ttyS0   </param>
     <param name="xsensmt_period">0.01</param>
     <param name="xsensmt_euler_period">0.005</param>
     <param name="xsensmt_gyro_period">0.005</param>


### PR DESCRIPTION
With @gabrielenava we were thinking about changing the role of the available laptops for the experiments; the pilot laptop will be the Alienware, the copilot will be the current pilot and the logging laptop will be the current copilot. Moreover, I changed the config file for the chest IMU since the serial cable is now fixed.