### PR TITLE
Add env variable for jets GUI

### DIFF
--- a/iRonCub-Mk3/extra/applications/pilot/iRonCubApp-turbines.xml
+++ b/iRonCub-Mk3/extra/applications/pilot/iRonCubApp-turbines.xml
@@ -18,6 +18,7 @@
 
 	<module>
 		<name>jets-GUI</name>
+        <environment>DESKTOP_SESSION=gnome</environment>
 		<node>${generic_node_1}</node>
 	</module>
 

--- a/iRonCub-Mk3/extra/applications/testbench/testbench-turbine.xml
+++ b/iRonCub-Mk3/extra/applications/testbench/testbench-turbine.xml
@@ -16,6 +16,7 @@
 
 	<module>
 		<name>jets-GUI</name>
+        <environment>DESKTOP_SESSION=gnome</environment>
 		<node>localhost</node>
 	</module>
 


### PR DESCRIPTION
Adds env variable `DESKTOP_SESSION=gnome` to allow buttons icons to appear on the jets-GUI