### PR TITLE
Clean up iRonCub-Mk3 application files

### DIFF
--- a/iRonCub-Mk3/extra/applications/dumper/iRonCubApp-turbines.xml
+++ b/iRonCub-Mk3/extra/applications/dumper/iRonCubApp-turbines.xml
@@ -15,29 +15,4 @@
 		<node>${logging_laptop}</node>
 	</module>
 
-	<module>
-		<name>bash</name>
-		<parameters>dumperScript_jet</parameters>
-		<node>${logging_laptop}</node>
-		<tag>data-dumperJetsFT</tag>
-	</module>
-
-	<connection>
-		<from>/iRonCubJets/body/stateExt:o</from>
-		<to>/dumper/jet/stateControlBoard</to>
-		<protocol>udp</protocol>
-	</connection>
-
-	<connection>
-		<from>/JetCatTurbines/data</from>
-		<to>/dumper/jet/data</to>
-		<protocol>udp</protocol>
-	</connection>
-
-	<connection>
-		<from>/iRonCub/jet/state:o</from>
-		<to>/dumper/jet/stateExt</to>
-		<protocol>udp</protocol>
-	</connection>
-
 </application>


### PR DESCRIPTION
Removing old YARP applications from the XML file.

The bash script `dumperScript_jet` is the older way of logging the data from the jets before `YarpRobotLogger`!